### PR TITLE
selinux: cleanup policy file

### DIFF
--- a/allow_clone_dev_access.cil
+++ b/allow_clone_dev_access.cil
@@ -1,4 +1,2 @@
 (allow container_t self (tun_socket (relabelfrom relabelto attach_queue)))
-(allow container_t tun_tap_device_t (chr_file (open read write ioctl)))
-(allow container_t container_file_t (file (open read write execute ioctl)))
-(allow container_t container_file_t (chr_file (open read write execute ioctl)))
+(allow container_t tun_tap_device_t (chr_file (read write open ioctl)))


### PR DESCRIPTION
The `allow container_t tun_tap_device_t:chr_file ...` file was
duplicated, and granting access to file
(`allow container_t tun_tap_device_t:file ...` is not required.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>